### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
               <option value="0.1000" selected>10 i/s</option>
               <option value="0.0500">20 i/s</option>
               <option value="0.0400">25 i/s</option>
-              <option value="0.03333">30 i/s</option>
+              <option value="0.03333334">30 i/s</option>
             </select>
           </p>
         </fieldset>


### PR DESCRIPTION
Sur la vidéo de badminton présentée en exemple qui est enregistré à 30 i/s, les deux premières frames affichés sont identiques
En effet il affiche la frame 1 à 0 s, puis à 0,033333 s, il affiche toujours la frame 1 car le temps n'a pas dépassé le 30e de seconde (qui est à 0,03333333…).
En modifiant la valeur à 0,03333334 on dépasse le 1/30e de seconde est le script affiche la frame 2.